### PR TITLE
Add time support to Kenat constructor and string output

### DIFF
--- a/src/Kenat.js
+++ b/src/Kenat.js
@@ -29,7 +29,7 @@ export class Kenat {
      * @param {string} [ethiopianDateStr] - The Ethiopian date string in 'yyyy/mm/dd' format.
      * @throws {Error} If the provided date string does not match the 'yyyy/mm/dd' format.
      */
-    constructor(ethiopianDateStr) {
+    constructor(ethiopianDateStr, timeObj = null) {
         if (!ethiopianDateStr) {
             // default to current Gregorian date → Ethiopian
             const today = new Date();
@@ -38,9 +38,12 @@ export class Kenat {
                 today.getMonth() + 1,
                 today.getDate()
             );
+            this.time = toEthiopianTime(today.getHours(), today.getMinutes());
+
         } else if (/^\d{4}\/\d{1,2}\/\d{1,2}$/.test(ethiopianDateStr)) {
             const [year, month, day] = ethiopianDateStr.split('/').map(Number);
             this.ethiopian = { year, month, day };
+            this.time = timeObj || { hour: 12, minute: 0, period: 'day' };
         } else {
             throw new Error("Kenat only accepts Ethiopian date in 'yyyy/mm/dd' format.");
         }
@@ -74,13 +77,31 @@ export class Kenat {
         return this.ethiopian;
     }
 
+
     /**
-     * Custom string representation of the Ethiopian date.
-     * 
-     * @returns {string} A string like "Ethiopian: 2017-9-15"
+     * Returns a string representation of the Ethiopian date and time.
+     *
+     * The format is: "Ethiopian: {year}-{month}-{day} {hh:mm period}".
+     * If the time is not available, hour and minute are replaced with '??'.
+     *
+     * @returns {string} The formatted Ethiopian date and time string.
      */
     toString() {
-        return `Ethiopian: ${this.ethiopian.year}-${this.ethiopian.month}-${this.ethiopian.day}`;
+        const { year, month, day } = this.ethiopian;
+        const { hour, minute, period } = this.time || { hour: '??', minute: '??', period: '' };
+        const timeStr = `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')} ${period}`;
+        return `Ethiopian: ${year}-${month}-${day} ${timeStr}`;
+    }
+
+    /**
+     * Sets the current time.
+     *
+     * @param {number} hour - The hour value to set.
+     * @param {number} minute - The minute value to set.
+     * @param {string} period - The period of the day (e.g., 'AM' or 'PM').
+     */
+    setTime(hour, minute, period) {
+        this.time = { hour, minute, period };
     }
 
     /**

--- a/src/timeConverter.js
+++ b/src/timeConverter.js
@@ -26,3 +26,6 @@ export function toGregorianTime(ethHour, minute = 0, period = 'day') {
     if (hour >= 24) hour -= 24;
     return { hour, minute };
 }
+
+
+// TODO: Implement time arthmetic functions

--- a/tests/KenatClass.test.js
+++ b/tests/KenatClass.test.js
@@ -33,7 +33,7 @@ describe('Kenat class', () => {
     test('toString should return Ethiopian date string', () => {
         const kenat = new Kenat("2016/9/15");
         const str = kenat.toString();
-        expect(str).toBe("Ethiopian: 2016-9-15");
+        expect(str).toBe("Ethiopian: 2016-9-15 12:00 day");
     });
 
     test('format returns Ethiopian date string with month name in English and Amharic', () => {

--- a/tests/kenat.test.js
+++ b/tests/kenat.test.js
@@ -35,7 +35,7 @@ describe('Kenat Ethiopian Calendar conversions', () => {
   test('Kenat instance toString and getGregorian', () => {
     const ethDateStr = '2017/09/14';
     const kenatInstance = new Kenat(ethDateStr);
-    expect(kenatInstance.toString()).toBe('Ethiopian: 2017-9-14');
+    expect(kenatInstance.toString()).toBe('Ethiopian: 2017-9-14 12:00 day');
     expect(kenatInstance.getGregorian()).toEqual({ year: 2025, month: 5, day: 22 });
   });
 });


### PR DESCRIPTION
This update adds support for Ethiopian time in the Kenat class:

- Modified the constructor to optionally accept a `timeObj` parameter alongside the Ethiopian date string.
  - If no date is provided, defaults to the current Gregorian date converted to Ethiopian date and time.
  - If a valid 'yyyy/mm/dd' format is provided, uses the provided time or defaults to 12:00 day.
- Added `toString()` enhancement to include formatted Ethiopian time.
- Introduced `setTime(hour, minute, period)` method for updating the time independently.

These changes allow full date-time representation and formatting in the Ethiopian calendar system.
