### PR TITLE
Sort holidays by Ethiopian date in `getHolidaysInMonth` function

### DIFF
--- a/src/holidays.js
+++ b/src/holidays.js
@@ -438,8 +438,6 @@ export function getHolidaysInMonth(ethYear, ethMonth) {
     // Add movable holidays if they fall in the month
     [fasika, siklet, eidFitr, eidAdha, moulid].forEach(movable => {
         if (movable.ethiopian.month === ethMonth) {
-            // Find corresponding holiday key for description, etc.
-            // For simplicity, match by key in movableHolidays
             let holidayKey = null;
 
             if (movable === fasika) holidayKey = 'fasika';
@@ -458,6 +456,9 @@ export function getHolidaysInMonth(ethYear, ethMonth) {
             }
         }
     });
+
+    // Sort holidays by day of the Ethiopian month
+    holidays.sort((a, b) => a.ethiopian.day - b.ethiopian.day);
 
     return holidays;
 }


### PR DESCRIPTION
**Sort holidays by Ethiopian date in `getHolidaysInMonth` function**

---

### 📝 Pull Request Description:

This PR updates the `getHolidaysInMonth` function to ensure that the list of returned holidays is sorted by the Ethiopian date (specifically, the `day` field).

### Changes Made:

* Added a `.sort()` operation at the end of the function to sort the `holidays` array based on `ethiopian.day`.
* This ensures consistent and logical ordering of holidays within a given Ethiopian month, which improves display and usability.

### Why:

Previously, holidays were returned in the order they were added (fixed first, then movable), which could lead to out-of-sequence dates. Sorting them provides a more intuitive and user-friendly output.