### PR TITLE
Refactor: Rename `ethiopianToGregorian` to `toGC` and `gregorianToEthiopian` to `toEC`

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -6,7 +6,7 @@ These are essential for most calendar applications.
 
 1. **Conversion Enhancements**
 
-   * [ ] Support conversion both ways: `gregorianToEthiopian()` and `ethiopianToGregorian()` renate this to better dev friendly names like toGregorian() and toEthiopian(). TODO: rename these methods.
+   * [ ] Support conversion both ways: `gregorianToEthiopian()` and `toGC()` renate this to better dev friendly names like toGregorian() and toEthiopian(). TODO: rename these methods.
 
    * [ ] Accept JavaScript `Date` object directly (and return one too). 
    * [ ] Add parsing and formatting helpers for ISO-8601 (`YYYY-MM-DD`).

--- a/Features.md
+++ b/Features.md
@@ -6,7 +6,7 @@ These are essential for most calendar applications.
 
 1. **Conversion Enhancements**
 
-   * [ ] Support conversion both ways: `gregorianToEthiopian()` and `toGC()` renate this to better dev friendly names like toGregorian() and toEthiopian(). TODO: rename these methods.
+   * [ ] Support conversion both ways: `toEC()` and `toGC()` renate this to better dev friendly names like toGregorian() and toEthiopian(). TODO: rename these methods.
 
    * [ ] Accept JavaScript `Date` object directly (and return one too). 
    * [ ] Add parsing and formatting helpers for ISO-8601 (`YYYY-MM-DD`).

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install kenat
 ## Quick Usage
 
 ```js
-import Kenat, { gregorianToEthiopian, toGC } from 'kenat';
+import Kenat, { toEC, toGC } from 'kenat';
 
 const k = new Kenat();
 console.log(k.getEthiopian()); // { year: 2017, month: 9, day: 23 }
@@ -53,7 +53,7 @@ console.log(k.getEthiopian()); // { year: 2017, month: 9, day: 23 }
 ### 🔄 Date Conversion
 
 ```js
-const eth = gregorianToEthiopian(2025, 5, 30);
+const eth = toEC(2025, 5, 30);
 console.log(eth); // { year: 2017, month: 9, day: 22 }
 
 const greg = toGC(2017, 9, 22);
@@ -164,7 +164,7 @@ console.log(grid.days);    // Array of day objects
 
 | Function                              | Description                |
 | ------------------------------------- | -------------------------- |
-| `gregorianToEthiopian(y, m, d)`       | → Ethiopian date           |
+| `toEC(y, m, d)`       | → Ethiopian date           |
 | `toGC(y, m, d)`       | → Gregorian date           |
 | `toGeez(num)`                         | → Ge'ez numeral            |
 | `toArabic(geezStr)`                   | → Arabic number from Ge'ez |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install kenat
 ## Quick Usage
 
 ```js
-import Kenat, { gregorianToEthiopian, ethiopianToGregorian } from 'kenat';
+import Kenat, { gregorianToEthiopian, toGC } from 'kenat';
 
 const k = new Kenat();
 console.log(k.getEthiopian()); // { year: 2017, month: 9, day: 23 }
@@ -56,7 +56,7 @@ console.log(k.getEthiopian()); // { year: 2017, month: 9, day: 23 }
 const eth = gregorianToEthiopian(2025, 5, 30);
 console.log(eth); // { year: 2017, month: 9, day: 22 }
 
-const greg = ethiopianToGregorian(2017, 9, 22);
+const greg = toGC(2017, 9, 22);
 console.log(greg); // { year: 2025, month: 5, day: 30 }
 ```
 
@@ -165,7 +165,7 @@ console.log(grid.days);    // Array of day objects
 | Function                              | Description                |
 | ------------------------------------- | -------------------------- |
 | `gregorianToEthiopian(y, m, d)`       | → Ethiopian date           |
-| `ethiopianToGregorian(y, m, d)`       | → Gregorian date           |
+| `toGC(y, m, d)`       | → Gregorian date           |
 | `toGeez(num)`                         | → Ge'ez numeral            |
 | `toArabic(geezStr)`                   | → Arabic number from Ge'ez |
 | `Kenat.getMonthGrid({ year, month })` | → Calendar grid            |

--- a/src/Kenat.js
+++ b/src/Kenat.js
@@ -1,4 +1,4 @@
-import { toGC, gregorianToEthiopian } from './conversions.js';
+import { toGC, toEC } from './conversions.js';
 import { printMonthCalendarGrid } from './render/printMonthCalendarGrid.js';
 import { monthNames, daysOfWeek } from './constants.js';
 import { toEthiopianTime, toGregorianTime } from './timeConverter.js';
@@ -34,7 +34,7 @@ export class Kenat {
         if (!ethiopianDateStr) {
             // default to current Gregorian date → Ethiopian
             const today = new Date();
-            this.ethiopian = gregorianToEthiopian(
+            this.ethiopian = toEC(
                 today.getFullYear(),
                 today.getMonth() + 1,
                 today.getDate()

--- a/src/Kenat.js
+++ b/src/Kenat.js
@@ -1,4 +1,4 @@
-import { ethiopianToGregorian, gregorianToEthiopian } from './conversions.js';
+import { toGC, gregorianToEthiopian } from './conversions.js';
 import { printMonthCalendarGrid } from './render/printMonthCalendarGrid.js';
 import { monthNames, daysOfWeek } from './constants.js';
 import { toEthiopianTime, toGregorianTime } from './timeConverter.js';
@@ -66,7 +66,7 @@ export class Kenat {
      */
     getGregorian() {
         const { year, month, day } = this.ethiopian;
-        return ethiopianToGregorian(year, month, day);
+        return toGC(year, month, day);
     }
 
     /**
@@ -149,7 +149,7 @@ export class Kenat {
 
         for (let day = 1; day <= daysInMonth; day++) {
             const ethDate = { year, month, day };
-            const gregDate = ethiopianToGregorian(year, month, day);
+            const gregDate = toGC(year, month, day);
             calendar.push({
                 ethiopian: {
                     ...ethDate,

--- a/src/conversions.js
+++ b/src/conversions.js
@@ -46,7 +46,7 @@ export function toGC(ethYear, ethMonth, ethDay) {
  * @param {number} gDay - Gregorian day
  * @returns {{year: number, month: number, day: number}} Ethiopian date
  */
-export function gregorianToEthiopian(gYear, gMonth, gDay) {
+export function toEC(gYear, gMonth, gDay) {
     const oneDay = 1000 * 60 * 60 * 24;
     const oneYear = 365 * oneDay;
     const fourYears = 1461 * oneDay; // 365*4 + 1 leap day

--- a/src/conversions.js
+++ b/src/conversions.js
@@ -9,7 +9,7 @@ import { dayOfYear, monthDayFromDayOfYear, isGregorianLeapYear } from './utils.j
  * @param {number} ethDay - Ethiopian day (1-30 for months 1-12, 1-5/6 for month 13)
  * @returns {{year: number, month: number, day: number}} Gregorian date
  */
-export function ethiopianToGregorian(ethYear, ethMonth, ethDay) {
+export function toGC(ethYear, ethMonth, ethDay) {
     // Get Gregorian new year date for the Ethiopian year
     const newYear = getGregorianDateOfEthiopianNewYear(ethYear);
 

--- a/src/holidays.js
+++ b/src/holidays.js
@@ -1,4 +1,4 @@
-import { gregorianToEthiopian, toGC } from './conversions.js';
+import { toEC, toGC } from './conversions.js';
 
 export const HolidayTags = {
     PUBLIC: 'public',
@@ -226,7 +226,7 @@ export function getFasikaDate(ethYear) {
     const gDay = easterGregorian.getUTCDate();
 
     // Convert Gregorian to Ethiopian
-    const { year: eYear, month: eMonth, day: eDay } = gregorianToEthiopian(gYear, gMonth, gDay);
+    const { year: eYear, month: eMonth, day: eDay } = toEC(gYear, gMonth, gDay);
 
     return {
         gregorian: {
@@ -265,7 +265,7 @@ export function getSikletDate(ethYear) {
     const gMonth = fasikaDate.getUTCMonth() + 1;
     const gDay = fasikaDate.getUTCDate();
 
-    const eth = gregorianToEthiopian(gYear, gMonth, gDay);
+    const eth = toEC(gYear, gMonth, gDay);
 
     return {
         gregorian: {
@@ -315,7 +315,7 @@ export function getEidFitrDate(ethiopianYear) {
         day: baseDate.getDate(),
     };
 
-    const ethiopianDate = gregorianToEthiopian(
+    const ethiopianDate = toEC(
         gregorianDate.year,
         gregorianDate.month,
         gregorianDate.day
@@ -358,7 +358,7 @@ export function getEidAdhaDate(ethiopianYear) {
         day: baseDate.getDate(),
     };
 
-    const ethiopianDate = gregorianToEthiopian(
+    const ethiopianDate = toEC(
         gregorianDate.year,
         gregorianDate.month,
         gregorianDate.day
@@ -399,7 +399,7 @@ export function getMoulidDate(ethiopianYear) {
         day: baseDate.getDate(),
     };
 
-    const ethiopianDate = gregorianToEthiopian(
+    const ethiopianDate = toEC(
         gregorianDate.year,
         gregorianDate.month,
         gregorianDate.day

--- a/src/holidays.js
+++ b/src/holidays.js
@@ -1,4 +1,4 @@
-import { gregorianToEthiopian, ethiopianToGregorian } from './conversions.js';
+import { gregorianToEthiopian, toGC } from './conversions.js';
 
 export const HolidayTags = {
     PUBLIC: 'public',

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { Kenat } from './Kenat.js';
 import { MonthGrid } from './MonthGrid.js';
-import { gregorianToEthiopian, ethiopianToGregorian } from './conversions.js';
+import { gregorianToEthiopian, toGC } from './conversions.js';
 import { toArabic, toGeez } from './geezConverter.js';  
 import { getHolidaysInMonth } from './holidays.js';
 
@@ -10,7 +10,7 @@ export default Kenat;
 // Named exports for the conversion functions
 export {
   gregorianToEthiopian,
-  ethiopianToGregorian,
+  toGC,
   toArabic,
   toGeez,
   getHolidaysInMonth,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { Kenat } from './Kenat.js';
 import { MonthGrid } from './MonthGrid.js';
-import { gregorianToEthiopian, toGC } from './conversions.js';
-import { toArabic, toGeez } from './geezConverter.js';  
+import { toEC, toGC } from './conversions.js';
+import { toArabic, toGeez } from './geezConverter.js';
 import { getHolidaysInMonth } from './holidays.js';
 
 // Default export is the Kenat class directly
@@ -9,7 +9,7 @@ export default Kenat;
 
 // Named exports for the conversion functions
 export {
-  gregorianToEthiopian,
+  toEC as toEC,
   toGC,
   toArabic,
   toGeez,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { ethiopianToGregorian, gregorianToEthiopian } from './conversions.js';
+import { toGC, gregorianToEthiopian } from './conversions.js';
 import { monthNames } from './constants.js';
 
 /**
@@ -81,6 +81,6 @@ export function getEthiopianDaysInMonth(year, month) {
  * @returns {number} The day of the week (0 for Sunday, 6 for Saturday).
  */
 export function getWeekday({ year, month, day }) {
-    const g = ethiopianToGregorian(year, month, day);
+    const g = toGC(year, month, day);
     return new Date(g.year, g.month - 1, g.day).getDay();
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { toGC, gregorianToEthiopian } from './conversions.js';
+import { toGC, toEC } from './conversions.js';
 import { monthNames } from './constants.js';
 
 /**

--- a/tests/conversions.test.js
+++ b/tests/conversions.test.js
@@ -1,69 +1,69 @@
-import { gregorianToEthiopian, ethiopianToGregorian } from "../src/conversions";
+import { gregorianToEthiopian, toGC } from "../src/conversions";
 
 describe('Ethiopian to Gregorian conversion', () => {
 
     test('Ethiopian to Gregorian: 2017-9-14 -> May 22, 2025', () => {
-        const result = ethiopianToGregorian(2017, 9, 14);
+        const result = toGC(2017, 9, 14);
         expect(result).toEqual({ year: 2025, month: 5, day: 22 });
     });
 
     test('Ethiopian to Gregorian: Pagumē 5, 2016 (2016-13-5) -> September 10, 2024', () => {
-        const result = ethiopianToGregorian(2016, 13, 5);
+        const result = toGC(2016, 13, 5);
         expect(result).toEqual({ year: 2024, month: 9, day: 10 });
     });
 
     test('Ethiopian to Gregorian Leap Year: 2011-13-6 (Pagumē 6, 2011) -> September 11, 2019', () => {
-        const result = ethiopianToGregorian(2011, 13, 6);
+        const result = toGC(2011, 13, 6);
         expect(result).toEqual({ year: 2019, month: 9, day: 11 });
     });
 
     test('Ethiopian to Gregorian Leap Year: Pagumē 6, 2019 (2019-13-6) -> September 11, 2027', () => {
-        const result = ethiopianToGregorian(2019, 13, 6);
+        const result = toGC(2019, 13, 6);
         expect(result).toEqual({ year: 2027, month: 9, day: 11 });
     });
 
     test('Ethiopian to Gregorian Leap Year: May 5, 2024 -> Miazia 27, 2016', () => {
-        const result = ethiopianToGregorian(2016, 8, 27);
+        const result = toGC(2016, 8, 27);
         expect(result).toEqual({ year: 2024, month: 5, day: 5 });
     });
 
         test('Ethiopian to Gregorian: Meskerem 1, 2016 (2016-1-1) -> September 11, 2023', () => {
-        const result = ethiopianToGregorian(2016, 1, 1);
+        const result = toGC(2016, 1, 1);
         expect(result).toEqual({ year: 2023, month: 9, day: 12 });
     });
 
     test('Ethiopian to Gregorian: Tahsas 30, 2015 (2015-4-30) -> January 8, 2023', () => {
-        const result = ethiopianToGregorian(2015, 4, 30);
+        const result = toGC(2015, 4, 30);
         expect(result).toEqual({ year: 2023, month: 1, day: 8 });
     });
 
     test('Ethiopian to Gregorian: Pagume 1, 2011 (2011-13-1) -> September 6, 2019', () => {
-        const result = ethiopianToGregorian(2011, 13, 1);
+        const result = toGC(2011, 13, 1);
         expect(result).toEqual({ year: 2019, month: 9, day: 6 });
     });
 
     test('Ethiopian to Gregorian: Meskerem 1, 1964 (1964-1-1) -> September 12, 1971', () => {
-        const result = ethiopianToGregorian(1964, 1, 1);
+        const result = toGC(1964, 1, 1);
         expect(result).toEqual({ year: 1971, month: 9, day: 12 });
     });
 
     test('Ethiopian to Gregorian: Pagume 6, 2007 (leap Pagume) -> September 11, 2015', () => {
-        const result = ethiopianToGregorian(2007, 13, 6);
+        const result = toGC(2007, 13, 6);
         expect(result).toEqual({ year: 2015, month: 9, day: 11 });
     });
 
     test('Ethiopian to Gregorian: Pagume 5, 2006 (non-leap Pagume) -> September 10, 2014', () => {
-        const result = ethiopianToGregorian(2006, 13, 5);
+        const result = toGC(2006, 13, 5);
         expect(result).toEqual({ year: 2014, month: 9, day: 10 });
     });
 
     test('Ethiopian to Gregorian: End of Ethiopian year (Pagume 5, 2015) -> September 10, 2023', () => {
-        const result = ethiopianToGregorian(2015, 13, 5);
+        const result = toGC(2015, 13, 5);
         expect(result).toEqual({ year: 2023, month: 9, day: 10 });
     });
 
     test('Ethiopian to Gregorian: Start of Ethiopian year (Meskerem 1, 2015) -> September 11, 2022', () => {
-        const result = ethiopianToGregorian(2015, 1, 1);
+        const result = toGC(2015, 1, 1);
         expect(result).toEqual({ year: 2022, month: 9, day: 11 });
     });
 });

--- a/tests/conversions.test.js
+++ b/tests/conversions.test.js
@@ -1,4 +1,4 @@
-import { gregorianToEthiopian, toGC } from "../src/conversions";
+import { toEC, toGC } from "../src/conversions";
 
 describe('Ethiopian to Gregorian conversion', () => {
 
@@ -70,81 +70,81 @@ describe('Ethiopian to Gregorian conversion', () => {
 
 describe('Gregorian to Ethiopian conversion', () => {
     test('Gregorian to Ethiopian: May 22, 2025 -> 2017-9-14', () => {
-        const result = gregorianToEthiopian(2025, 5, 22);
+        const result = toEC(2025, 5, 22);
         expect(result).toEqual({ year: 2017, month: 9, day: 14 });
     });
 
     test('Gregorian to Ethiopian Leap Year: February 29, 2020 -> Yekatit 22, 2012', () => {
-        const result = gregorianToEthiopian(2020, 2, 29);
+        const result = toEC(2020, 2, 29);
         expect(result).toEqual({ year: 2012, month: 6, day: 21 });
     });
 
     test('Gregorian to Ethiopian Leap Year: May 5, 2024 -> Miazia 27, 2016', () => {
-        const result = gregorianToEthiopian(2024, 5, 5);
+        const result = toEC(2024, 5, 5);
         expect(result).toEqual({ year: 2016, month: 8, day: 27 });
     });
 
     test('Gregorian to Ethiopian: September 10, 2024 -> 2016-13-5 (Pagumē 5, 2016)', () => {
-        const result = gregorianToEthiopian(2024, 9, 10);
+        const result = toEC(2024, 9, 10);
         expect(result).toEqual({ year: 2016, month: 13, day: 5 });
     });
 
     test('Gregorian to Ethiopian Leap Year: September 11, 2019 -> 2011-13-6 (Pagumē 6, 2011)', () => {
-        const result = gregorianToEthiopian(2019, 9, 11);
+        const result = toEC(2019, 9, 11);
         expect(result).toEqual({ year: 2011, month: 13, day: 6 });
     });
 
     test('Gregorian to Ethiopian Leap Year: September 11, 2027 -> 2019-13-6 (Pagumē 6, 2019)', () => {
-        const result = gregorianToEthiopian(2027, 9, 11);
+        const result = toEC(2027, 9, 11);
         expect(result).toEqual({ year: 2019, month: 13, day: 6 });
     });
 
     test('Gregorian to Ethiopian: January 1, 2000 -> 1992-4-23', () => {
-        const result = gregorianToEthiopian(2000, 1, 1);
+        const result = toEC(2000, 1, 1);
         expect(result).toEqual({ year: 1992, month: 4, day: 22 });
     });
 
     test('Gregorian to Ethiopian: Out of range year throws error', () => {
-        expect(() => gregorianToEthiopian(1800, 1, 1)).toThrow('Out of range input year: 1800');
-        expect(() => gregorianToEthiopian(2200, 1, 1)).toThrow('Out of range input year: 2200');
+        expect(() => toEC(1800, 1, 1)).toThrow('Out of range input year: 1800');
+        expect(() => toEC(2200, 1, 1)).toThrow('Out of range input year: 2200');
     });
 
     test('Gregorian to Ethiopian: September 12, 1971 (base date) -> 1964-1-1', () => {
-        const result = gregorianToEthiopian(1971, 9, 12);
+        const result = toEC(1971, 9, 12);
         expect(result).toEqual({ year: 1964, month: 1, day: 1 });
     });
 
     test('Gregorian to Ethiopian: December 31, 2100 (upper bound) -> valid Ethiopian date', () => {
-        const result = gregorianToEthiopian(2100, 12, 31);
+        const result = toEC(2100, 12, 31);
         expect(result.year).toBeGreaterThanOrEqual(2092);
         expect(result.month).toBeGreaterThanOrEqual(4);
         expect(result.day).toBeGreaterThanOrEqual(20);
     });
 
     test('Gregorian to Ethiopian: January 1, 1900 (lower bound) -> valid Ethiopian date', () => {
-        const result = gregorianToEthiopian(1900, 1, 1);
+        const result = toEC(1900, 1, 1);
         expect(result.year).toBeLessThanOrEqual(1892);
         expect(result.month).toBeGreaterThanOrEqual(4);
         expect(result.day).toBeGreaterThanOrEqual(22);
     });
 
     test('Gregorian to Ethiopian: End of Gregorian leap year (December 31, 2020)', () => {
-        const result = gregorianToEthiopian(2020, 12, 31);
+        const result = toEC(2020, 12, 31);
         expect(result).toEqual({ year: 2013, month: 4, day: 22 });
     });
 
     test('Gregorian to Ethiopian: Start of Gregorian leap year (January 1, 2020)', () => {
-        const result = gregorianToEthiopian(2020, 1, 1);
+        const result = toEC(2020, 1, 1);
         expect(result).toEqual({ year: 2012, month: 4, day: 22 });
     });
 
     test('Gregorian to Ethiopian: Last day of Ethiopian year (September 10, 2023)', () => {
-        const result = gregorianToEthiopian(2023, 9, 10);
+        const result = toEC(2023, 9, 10);
         expect(result).toEqual({ year: 2015, month: 13, day: 5 });
     });
 
     test('Gregorian to Ethiopian: Leap Pagume (September 11, 2015)', () => {
-        const result = gregorianToEthiopian(2023, 9, 11);
+        const result = toEC(2023, 9, 11);
         expect(result).toEqual({ year: 2015, month: 13, day: 6 });
     });
 });


### PR DESCRIPTION
**Refactor: Rename `ethiopianToGregorian` to `toGC` and `gregorianToEthiopian` to `toEC`**

---

### 📝 Pull Request Description:

This PR refactors the Ethiopian-Gregorian date conversion function names for improved clarity and brevity:

* `ethiopianToGregorian` ➜ `toGC`
* `gregorianToEthiopian` ➜ `toEC`

### Why:

* Makes the function names shorter and easier to use across the codebase
* Keeps naming consistent with other helper functions and internal usage

All references to the old names have been updated accordingly. No functional logic has changed — this is a purely renaming-focused refactor.
